### PR TITLE
Added basic statistics counter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build
 node_modules
 env.json
 .env
+*-v8.log
+v8.json

--- a/src/handlers/command.js
+++ b/src/handlers/command.js
@@ -22,7 +22,7 @@ class CommandHandler extends EventEmitter {
     const commandRegex = new RegExp(`\([${this.modifier}][A-z])\\w+`, 'gim');
     const found = message.match(commandRegex);
 
-    if (!found && found.length > 1 && found.length <= 0) {
+    if (found && found.length > 1 && found.length <= 0) {
       return false;
     }
 

--- a/src/handlers/command.js
+++ b/src/handlers/command.js
@@ -22,7 +22,7 @@ class CommandHandler extends EventEmitter {
     const commandRegex = new RegExp(`\([${this.modifier}][A-z])\\w+`, 'gim');
     const found = message.match(commandRegex);
 
-    if (found && found.length > 1 && found.length <= 0) {
+    if (!found) {
       return false;
     }
 

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -1,3 +1,4 @@
 import Logger from './logger';
+import Stats from './stats';
 
-export { Logger };
+export { Logger, Stats };

--- a/src/managers/stats.js
+++ b/src/managers/stats.js
@@ -1,0 +1,25 @@
+/**
+ * Very basic stats class
+ */
+class Stats {
+  /**
+   * Creates an instance of Stats.
+   */
+  constructor() {
+    this._stats = {};
+  }
+
+  get(key) {
+    return this._stats[key];
+  }
+
+  set(key, value) {
+    this._stats[key] = value;
+  }
+
+  increment(key, amount) {
+    this.set(key, (this.get(key) || 0) + (amount || 1));
+  }
+}
+
+export default Stats;


### PR DESCRIPTION
- Ignore Node V8 logs (.gitignore)
- Removed unnecessary checks in `CommandHandler` class that caused every message to register as a command
- Created a basic key/value statistics class with get/set/increment methods
- Now counts command stats key in the format `commands-[USER ID]-[SERVER ID].[CHANNEL ID]` to make it easier once uploaded to API - will allow for separation of statistics by user, server, channel etc.