### PR TITLE
Changed log.error to log.severe

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@ bot.on('guildCreate', guild => {
 });
 
 bot.on('error', e => {
-  log.error(e);
+  log.severe(e);
 });
 
 bot.login(process.env.DISCORD_BOT_TOKEN).catch(e => log.severe(e));


### PR DESCRIPTION
The logger class doesn't have an error method, it can either be used as `console.error()` as it is injected to the default console logging functions or `Logger.severe()`